### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is an implementation of the Model Context Protocol (MCP) that integrates with Google's Gemini API to provide analytical thinking capabilities without code generation.
 
+<a href="https://glama.ai/mcp/servers/q8pdxnf129">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/q8pdxnf129/badge" alt="Gemini Thinking Server MCP server" />
+</a>
+
 ## Overview
 
 The Gemini Thinking Server is a specialized MCP server that leverages Google's Gemini model to provide sequential thinking and problem-solving capabilities. It allows for:


### PR DESCRIPTION
This PR adds a badge for the [Gemini Thinking Server](https://glama.ai/mcp/servers/q8pdxnf129) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/q8pdxnf129">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/q8pdxnf129/badge" alt="Gemini Thinking Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.